### PR TITLE
tabs: received payments

### DIFF
--- a/network/backend/backend.go
+++ b/network/backend/backend.go
@@ -32,6 +32,8 @@ type Backend interface {
 
 	GetInvoice(context.Context, string) (*models.Invoice, error)
 
+	ListInvoices(context.Context) ([]*models.Invoice, error)
+
 	DecodePayReq(context.Context, string) (*models.PayReq, error)
 
 	SendPayment(context.Context, *models.PayReq) (*models.Payment, error)

--- a/network/backend/lnd/lnd.go
+++ b/network/backend/lnd/lnd.go
@@ -591,6 +591,26 @@ func (l Backend) GetInvoice(ctx context.Context, RHash string) (*models.Invoice,
 	return invoice, nil
 }
 
+func (l Backend) ListInvoices(ctx context.Context) ([]*models.Invoice, error) {
+	l.logger.Debug("List invoices...")
+	clt, err := l.Client(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer clt.Close()
+
+	req := &lnrpc.ListInvoiceRequest{NumMaxInvoices: 0}
+	resp, err := clt.ListInvoices(ctx, req)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	invoices := make([]*models.Invoice, len(resp.Invoices))
+	for i := range resp.Invoices {
+		invoices[i] = lookupInvoiceProtoToInvoice(resp.Invoices[i])
+	}
+	return invoices, nil
+}
+
 func (l Backend) SendPayment(ctx context.Context, payreq *models.PayReq) (*models.Payment, error) {
 	l.logger.Debug("Send payment...",
 		logging.String("destination", payreq.Destination),

--- a/network/backend/lnd/proto.go
+++ b/network/backend/lnd/proto.go
@@ -27,7 +27,7 @@ func protoToChannelsBalance(w *lnrpc.ChannelBalanceResponse) *models.ChannelsBal
 }
 
 func addInvoiceProtoToInvoice(req *lnrpc.Invoice, resp *lnrpc.AddInvoiceResponse) *models.Invoice {
-	return &models.Invoice{
+	inv := &models.Invoice{
 		Expiry:         req.GetExpiry(),
 		Amount:         req.GetValue(),
 		Description:    req.GetMemo(),
@@ -36,10 +36,17 @@ func addInvoiceProtoToInvoice(req *lnrpc.Invoice, resp *lnrpc.AddInvoiceResponse
 		PaymentRequest: resp.GetPaymentRequest(),
 		Index:          resp.GetAddIndex(),
 	}
+	// Determine kind: if PaymentRequest is empty, treat as keysend
+	if inv.PaymentRequest == "" {
+		inv.Kind = models.KindKeysend
+	} else {
+		inv.Kind = models.KindInvoice
+	}
+	return inv
 }
 
 func lookupInvoiceProtoToInvoice(resp *lnrpc.Invoice) *models.Invoice {
-	return &models.Invoice{
+	inv := &models.Invoice{
 		Index:            resp.GetAddIndex(),
 		Amount:           resp.GetValue(),
 		AmountPaid:       resp.GetAmtPaidSat(),
@@ -57,6 +64,12 @@ func lookupInvoiceProtoToInvoice(resp *lnrpc.Invoice) *models.Invoice {
 		CLTVExpiry:       resp.GetCltvExpiry(),
 		Private:          resp.GetPrivate(),
 	}
+	if inv.PaymentRequest == "" {
+		inv.Kind = models.KindKeysend
+	} else {
+		inv.Kind = models.KindInvoice
+	}
+	return inv
 }
 
 func listChannelsProtoToChannels(r *lnrpc.ListChannelsResponse) []*models.Channel {

--- a/network/backend/mock/mock.go
+++ b/network/backend/mock/mock.go
@@ -125,6 +125,16 @@ func (b *Backend) GetInvoice(ctx context.Context, hash string) (*models.Invoice,
 	return &invoice, nil
 }
 
+func (b *Backend) ListInvoices(ctx context.Context) ([]*models.Invoice, error) {
+	// Return current map values; in mock we don't simulate history beyond created
+	result := make([]*models.Invoice, 0, len(b.invoices))
+	for _, inv := range b.invoices {
+		invCopy := inv
+		result = append(result, &invCopy)
+	}
+	return result, nil
+}
+
 func New(c *config.Network) *Backend {
 	return &Backend{
 		invoices: make(map[string]models.Invoice),

--- a/network/models/invoice.go
+++ b/network/models/invoice.go
@@ -6,6 +6,13 @@ import (
 	"github.com/edouardparis/lntop/logging"
 )
 
+type ReceivedKind int
+
+const (
+	KindInvoice ReceivedKind = iota
+	KindKeysend
+)
+
 type Invoice struct {
 	// Index: index of this invoice.
 	// Each newly created invoice will increment
@@ -37,6 +44,8 @@ type Invoice struct {
 	CLTVExpiry uint64
 	// Private: Whether this invoice should include routing hints for private channels.
 	Private bool
+	// Kind indicates whether this was a regular invoice or a keysend (spontaneous) payment.
+	Kind ReceivedKind
 }
 
 func (m Invoice) GetRHash() string {

--- a/pubsub/pubsub.go
+++ b/pubsub/pubsub.go
@@ -33,11 +33,19 @@ func (p *PubSub) invoices(ctx context.Context, sub chan *events.Event) {
 
 	go func() {
 		for invoice := range invoices {
-			p.logger.Debug("receive invoice", logging.Object("invoice", invoice))
+			p.logger.Debug(
+				"receive invoice",
+				logging.Object("invoice", invoice),
+			)
+
 			if invoice.Settled {
-				sub <- events.New(events.InvoiceSettled)
+				sub <- events.NewWithData(
+					events.InvoiceSettled, invoice,
+				)
 			} else {
-				sub <- events.New(events.InvoiceCreated)
+				sub <- events.NewWithData(
+					events.InvoiceCreated, invoice,
+				)
 			}
 		}
 		p.wg.Done()

--- a/ui/controller.go
+++ b/ui/controller.go
@@ -115,6 +115,12 @@ func (c *controller) SetModels(ctx context.Context) error {
 		return err
 	}
 
+	// Populate received invoices initially
+	err = c.models.RefreshReceivedFromNetwork(ctx)
+	if err != nil {
+		return err
+	}
+
 	return c.models.RefreshChannels(ctx)
 }
 
@@ -182,6 +188,7 @@ func (c *controller) Listen(ctx context.Context, g *gocui.Gui, sub chan *events.
 				c.models.RefreshChannelsBalance,
 				c.models.RefreshChannels,
 				c.models.RefreshForwardingHistory,
+				c.models.RefreshReceived(event.Data),
 			)
 		case events.PeerUpdated:
 			refresh(
@@ -318,6 +325,16 @@ func (c *controller) OnEnter(g *gocui.Gui, v *gocui.View) error {
 			}
 			c.views.Main = c.views.FwdingHist
 			err = c.views.FwdingHist.Set(g, 11, 6, maxX-1, maxY)
+			if err != nil {
+				return err
+			}
+		case views.RECEIVED:
+			err := c.views.Main.Delete(g)
+			if err != nil {
+				return err
+			}
+			c.views.Main = c.views.Received
+			err = c.views.Received.Set(g, 11, 6, maxX-1, maxY)
 			if err != nil {
 				return err
 			}

--- a/ui/models/models.go
+++ b/ui/models/models.go
@@ -21,6 +21,7 @@ type Models struct {
 	Transactions    *Transactions
 	RoutingLog      *RoutingLog
 	FwdingHist      *FwdingHist
+	Received        *Received
 }
 
 func New(app *app.App) *Models {
@@ -51,6 +52,7 @@ func New(app *app.App) *Models {
 		Transactions:    &Transactions{},
 		RoutingLog:      &RoutingLog{},
 		FwdingHist:      &fwdingHist,
+		Received:        &Received{},
 	}
 }
 

--- a/ui/models/received.go
+++ b/ui/models/received.go
@@ -1,0 +1,86 @@
+package models
+
+import (
+	"context"
+	"sort"
+	"sync"
+
+	netmodels "github.com/edouardparis/lntop/network/models"
+)
+
+type ReceivedSort func(*netmodels.Invoice, *netmodels.Invoice) bool
+
+type Received struct {
+	list []*netmodels.Invoice
+	sort ReceivedSort
+	mu   sync.RWMutex
+}
+
+func (r *Received) List() []*netmodels.Invoice { return r.list }
+func (r *Received) Len() int                   { return len(r.list) }
+func (r *Received) Swap(i, j int)              { r.list[i], r.list[j] = r.list[j], r.list[i] }
+func (r *Received) Less(i, j int) bool         { return r.sort(r.list[i], r.list[j]) }
+
+func (r *Received) Sort(s ReceivedSort) {
+	if s == nil {
+		return
+	}
+	r.sort = s
+	sort.Sort(r)
+}
+
+func (r *Received) Contains(inv *netmodels.Invoice) bool {
+	if inv == nil {
+		return false
+	}
+	for _, it := range r.list {
+		if it.GetRHash() == inv.GetRHash() {
+			return true
+		}
+	}
+	return false
+}
+
+func (r *Received) Add(inv *netmodels.Invoice) {
+	if inv == nil {
+		return
+	}
+	if !inv.Settled {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.Contains(inv) {
+		return
+	}
+	r.list = append(r.list, inv)
+	if r.sort != nil {
+		sort.Sort(r)
+	}
+}
+
+// RefreshReceived consumes an update (expected *netmodels.Invoice) and updates the list.
+func (m *Models) RefreshReceived(update interface{}) func(ctx context.Context) error {
+	return func(ctx context.Context) error {
+		inv, ok := update.(*netmodels.Invoice)
+		if !ok {
+			return nil
+		}
+		m.Received.Add(inv)
+		return nil
+	}
+}
+
+// RefreshReceivedFromNetwork fetches invoices from backend and populates Received model.
+func (m *Models) RefreshReceivedFromNetwork(ctx context.Context) error {
+	invoices, err := m.network.ListInvoices(ctx)
+	if err != nil {
+		return err
+	}
+	for _, inv := range invoices {
+		if inv != nil && inv.Settled {
+			m.Received.Add(inv)
+		}
+	}
+	return nil
+}

--- a/ui/views/menu.go
+++ b/ui/views/menu.go
@@ -18,6 +18,7 @@ var menu = []string{
 	"TRANSAC",
 	"ROUTING",
 	"FWDHIST",
+	"RECEIVED",
 }
 
 type Menu struct {
@@ -88,6 +89,8 @@ func (h Menu) Current() string {
 			return ROUTING
 		case "FWDHIST":
 			return FWDINGHIST
+		case "RECEIVED":
+			return RECEIVED
 		}
 	}
 	return ""

--- a/ui/views/received.go
+++ b/ui/views/received.go
@@ -1,0 +1,265 @@
+package views
+
+import (
+	"bytes"
+	"fmt"
+	"time"
+
+	"github.com/awesome-gocui/gocui"
+	"golang.org/x/text/language"
+	"golang.org/x/text/message"
+
+	"github.com/edouardparis/lntop/config"
+	netmodels "github.com/edouardparis/lntop/network/models"
+	"github.com/edouardparis/lntop/ui/color"
+	"github.com/edouardparis/lntop/ui/models"
+)
+
+const (
+	RECEIVED         = "received"
+	RECEIVED_COLUMNS = "received_columns"
+	RECEIVED_FOOTER  = "received_footer"
+)
+
+var DefaultReceivedColumns = []string{
+	"TYPE",
+	"TIME",
+	"AMOUNT",
+	"MEMO",
+	"R_HASH",
+}
+
+type Received struct {
+	cfg *config.View
+
+	columns           []receivedColumn
+	columnHeadersView *gocui.View
+	view              *gocui.View
+	received          *models.Received
+
+	ox, oy int
+	cx, cy int
+}
+
+type receivedColumn struct {
+	name    string
+	width   int
+	display func(*netmodels.Invoice, ...color.Option) string
+}
+
+func (c Received) Name() string             { return RECEIVED }
+func (c *Received) Wrap(v *gocui.View) View { c.view = v; return c }
+func (c Received) Origin() (int, int)       { return c.ox, c.oy }
+func (c Received) Cursor() (int, int)       { return c.cx, c.cy }
+
+func (c *Received) SetCursor(cx, cy int) error {
+	if err := cursorCompat(c.columnHeadersView, cx, 0); err != nil {
+		return err
+	}
+	if err := c.columnHeadersView.SetCursor(cx, 0); err != nil {
+		return err
+	}
+	if err := cursorCompat(c.view, cx, cy); err != nil {
+		return err
+	}
+	if err := c.view.SetCursor(cx, cy); err != nil {
+		return err
+	}
+	c.cx, c.cy = cx, cy
+	return nil
+}
+
+func (c *Received) SetOrigin(ox, oy int) error {
+	if err := c.columnHeadersView.SetOrigin(ox, 0); err != nil {
+		return err
+	}
+	if err := c.view.SetOrigin(ox, oy); err != nil {
+		return err
+	}
+	c.ox, c.oy = ox, oy
+	return nil
+}
+
+func (c *Received) Speed() (int, int, int, int) {
+	up, down := 0, 0
+	if c.Index() > 0 {
+		up = 1
+	}
+	if c.Index() < c.received.Len()-1 {
+		down = 1
+	}
+	// columns have static widths: TYPE(7) TIME(20) AMOUNT(12) MEMO(40) R_HASH(64)
+	return 7, 0, down, up
+}
+
+func (c *Received) Limits() (int, int) {
+	_, page := c.view.Size()
+	full := c.received.Len()
+	return page, full
+}
+
+func (c Received) Index() int { _, oy := c.view.Origin(); _, cy := c.view.Cursor(); return cy + oy }
+
+func (c Received) Delete(g *gocui.Gui) error {
+	if err := g.DeleteView(RECEIVED_COLUMNS); err != nil {
+		return err
+	}
+	if err := g.DeleteView(RECEIVED); err != nil {
+		return err
+	}
+	return g.DeleteView(RECEIVED_FOOTER)
+}
+
+func (c *Received) Set(g *gocui.Gui, x0, y0, x1, y1 int) error {
+	var err error
+	setCursor := false
+	c.columnHeadersView, err = g.SetView(RECEIVED_COLUMNS, x0-1, y0, x1+2, y0+2, 0)
+	if err != nil {
+		if err != gocui.ErrUnknownView {
+			return err
+		}
+		setCursor = true
+	}
+	c.columnHeadersView.Frame = false
+	c.columnHeadersView.BgColor = gocui.ColorGreen
+	c.columnHeadersView.FgColor = gocui.ColorBlack
+
+	c.view, err = g.SetView(RECEIVED, x0-1, y0+1, x1+2, y1-1, 0)
+	if err != nil {
+		if err != gocui.ErrUnknownView {
+			return err
+		}
+		setCursor = true
+	}
+	c.view.Frame = false
+	c.view.Autoscroll = false
+	c.view.SelBgColor = gocui.ColorCyan
+	c.view.SelFgColor = gocui.ColorBlack | gocui.AttrDim
+	c.view.Highlight = true
+	c.display()
+
+	if setCursor {
+		if err := c.SetOrigin(c.ox, c.oy); err != nil {
+			return err
+		}
+		if err := c.SetCursor(c.cx, c.cy); err != nil {
+			return err
+		}
+	}
+
+	footer, err := g.SetView(RECEIVED_FOOTER, x0-1, y1-2, x1+2, y1, 0)
+	if err != nil {
+		if err != gocui.ErrUnknownView {
+			return err
+		}
+	}
+	footer.Frame = false
+	footer.BgColor = gocui.ColorCyan
+	footer.FgColor = gocui.ColorBlack
+	footer.Rewind()
+	blackBg := color.Black(color.Background)
+	fmt.Fprintln(footer, fmt.Sprintf("%s%s %s%s",
+		blackBg("F2"), "Menu",
+		blackBg("F10"), "Quit",
+	))
+	return nil
+}
+
+func (c *Received) display() {
+	c.columnHeadersView.Rewind()
+	var buffer bytes.Buffer
+	for i := range c.columns {
+		buffer.WriteString(c.columns[i].name)
+		buffer.WriteString(" ")
+	}
+	fmt.Fprintln(c.columnHeadersView, buffer.String())
+
+	c.view.Rewind()
+	for _, inv := range c.received.List() {
+		var b bytes.Buffer
+		for i := range c.columns {
+			b.WriteString(c.columns[i].display(inv))
+			b.WriteString(" ")
+		}
+		fmt.Fprintln(c.view, b.String())
+	}
+}
+
+func NewReceived(cfg *config.View, rec *models.Received) *Received {
+	received := &Received{cfg: cfg, received: rec}
+
+	printer := message.NewPrinter(language.English)
+
+	cols := DefaultReceivedColumns
+	if cfg != nil && len(cfg.Columns) != 0 {
+		cols = cfg.Columns
+	}
+
+	received.columns = make([]receivedColumn, len(cols))
+	for i := range cols {
+		switch cols[i] {
+		case "TYPE":
+			received.columns[i] = receivedColumn{
+				width: 7,
+				name:  fmt.Sprintf("%-7s", cols[i]),
+				display: func(inv *netmodels.Invoice, opts ...color.Option) string {
+					label := "invoice"
+					col := color.White(opts...)
+					if inv.Kind == netmodels.KindKeysend || inv.PaymentRequest == "" {
+						label = "keysend"
+						col = color.White(opts...) // make keysend white like invoice
+					}
+					return col(fmt.Sprintf("%-7s", label))
+				},
+			}
+		case "TIME":
+			received.columns[i] = receivedColumn{
+				width: 20,
+				name:  fmt.Sprintf("%20s", cols[i]),
+				display: func(inv *netmodels.Invoice, opts ...color.Option) string {
+					// Prefer settle date, fallback to creation
+					ts := inv.SettleDate
+					if ts == 0 {
+						ts = inv.CreationDate
+					}
+					return color.White(opts...)(fmt.Sprintf("%20s", time.Unix(ts, 0).Format("15:04:05 Jan _2")))
+				},
+			}
+		case "AMOUNT":
+			received.columns[i] = receivedColumn{
+				width: 12,
+				name:  fmt.Sprintf("%12s", cols[i]),
+				display: func(inv *netmodels.Invoice, opts ...color.Option) string {
+					amt := inv.AmountPaid
+					if amt == 0 {
+						amt = inv.Amount
+					}
+					return color.Yellow(opts...)(printer.Sprintf("%12d", amt))
+				},
+			}
+		case "MEMO":
+			received.columns[i] = receivedColumn{
+				width: 40,
+				name:  fmt.Sprintf("%-40s", cols[i]),
+				display: func(inv *netmodels.Invoice, opts ...color.Option) string {
+					return color.White(opts...)(fmt.Sprintf("%-40s", inv.Description))
+				},
+			}
+		case "R_HASH":
+			received.columns[i] = receivedColumn{
+				width: 64,
+				name:  fmt.Sprintf("%-64s", cols[i]),
+				display: func(inv *netmodels.Invoice, opts ...color.Option) string {
+					return color.White(opts...)(fmt.Sprintf("%-64s", inv.GetRHash()))
+				},
+			}
+		default:
+			received.columns[i] = receivedColumn{
+				width:   10,
+				name:    fmt.Sprintf("%-10s", cols[i]),
+				display: func(inv *netmodels.Invoice, opts ...color.Option) string { return "" },
+			}
+		}
+	}
+	return received
+}

--- a/ui/views/views.go
+++ b/ui/views/views.go
@@ -32,6 +32,7 @@ type Views struct {
 	Transaction  *Transaction
 	Routing      *Routing
 	FwdingHist   *FwdingHist
+	Received     *Received
 }
 
 func (v Views) Get(vi *gocui.View) View {
@@ -53,6 +54,8 @@ func (v Views) Get(vi *gocui.View) View {
 		return v.Routing.Wrap(vi)
 	case FWDINGHIST:
 		return v.FwdingHist.Wrap(vi)
+	case RECEIVED:
+		return v.Received.Wrap(vi)
 	default:
 		return nil
 	}
@@ -110,6 +113,7 @@ func New(cfg config.Views, m *models.Models) *Views {
 		Transaction:  NewTransaction(m.Transactions),
 		Routing:      NewRouting(cfg.Routing, m.RoutingLog, m.Channels),
 		FwdingHist:   NewFwdingHist(cfg.FwdingHist, m.FwdingHist),
+		Received:     NewReceived(nil, m.Received),
 		Main:         main,
 	}
 }


### PR DESCRIPTION
This PR adds a new tab to display payments that the backing lnd node received. Invoices and keysends are distinguished thus far.

<img width="1443" height="143" alt="image" src="https://github.com/user-attachments/assets/e1501569-7a18-4b72-88cf-2db3508081f2" />
