### PR TITLE
Fix channel loading and age refresh issues

### DIFF
--- a/ui/commands.go
+++ b/ui/commands.go
@@ -131,7 +131,7 @@ func loadPaymentsCmd(net *network.Network, logger logging.Logger) tea.Cmd {
 
 func loadChannelsCmd(net *network.Network, logger logging.Logger, blockHeight uint32, snapshot map[string]channelSnapshot) tea.Cmd {
 	return func() tea.Msg {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 
 		channels, err := net.ListChannels(ctx, options.WithChannelPending)

--- a/ui/models/channels.go
+++ b/ui/models/channels.go
@@ -108,8 +108,11 @@ func (c *Channels) Update(newChannel *models.Channel) {
 	oldChannel.CSVDelay = newChannel.CSVDelay
 	oldChannel.Private = newChannel.Private
 	oldChannel.PendingHTLC = newChannel.PendingHTLC
-	oldChannel.Age = newChannel.Age
 	oldChannel.BlocksTilMaturity = newChannel.BlocksTilMaturity
+
+	if newChannel.Age > 0 {
+		oldChannel.Age = newChannel.Age
+	}
 
 	if newChannel.LastUpdate != nil {
 		oldChannel.LastUpdate = newChannel.LastUpdate


### PR DESCRIPTION
This PR contains two fixes:

1. Increase channel loading timeout from 5s to 30s to prevent initial channel loading failures.

2. Prevent channel Age from being overwritten by zero during channel refreshes.
   Some refresh paths returned channels with Age=0, causing the displayed age to flip between the correct value and 00m.

Tested locally with a live lnd node.